### PR TITLE
Neutralize expo-doctor warnings; reduce redundant logs

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -57,10 +57,6 @@ jobs:
         with:
           node-version: 24.x
 
-      - name: Check Node.js and npm version
-        run: |
-          node --version
-          npm --version
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
@@ -80,10 +76,6 @@ jobs:
         with:
           node-version: 24.x
 
-      - name: Check Node.js and npm version
-        run: |
-          node --version
-          npm --version
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
@@ -103,10 +95,6 @@ jobs:
         with:
           node-version: 24.x
 
-      - name: Check Node.js and npm version
-        run: |
-          node --version
-          npm --version
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
@@ -133,3 +121,4 @@ jobs:
       - name: Expo Doctor Check
         working-directory: ./aquawatch_mobile_app
         run: npx expo-doctor
+        continue-on-error: true


### PR DESCRIPTION
## What was changed
- Expo warning will not cause build failures 
- We only need to log node versions once