### PR TITLE
Use org level tokens

### DIFF
--- a/.github/workflows/frontend_build.yml
+++ b/.github/workflows/frontend_build.yml
@@ -40,11 +40,11 @@ jobs:
       - name: 🚀 Build Android app
         working-directory: ./aquawatch_mobile_app
         env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EXPO_TOKEN: ${{ secrets.EXPO_ORG_SECRET }}
         run: eas build --platform android --non-interactive --no-wait
 
       - name: 🚀 Build Apple app
         working-directory: ./aquawatch_mobile_app
         env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EXPO_TOKEN: ${{ secrets.EXPO_ORG_SECRET }}
         run: eas build --platform ios --non-interactive --no-wait


### PR DESCRIPTION
## What was changed
- This rotates Expo token to use `EXPO_ORG_SECRET` to move away from using personal tokens